### PR TITLE
Update test.yml - don't run remote tests for now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,111 +51,112 @@ jobs:
   ###########################################################################
   # 2 - Deploy this PR to a temp Heroku app and run tests against deployed app (in addition to 'local')
   ###########################################################################
-  remote:
-    if: false  # These e2d depployment tests are super useful, but require you to add a HEROKU_API_KEY to your repo's actions secrets.
-    runs-on: ubuntu-latest
-    env:
-      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-      API_KEY: ci-test-key
-      # also note that github CI doesn't have access to your app's config vars, so here we're setting the remote
-      # server type to streamable HTTP. Folks using SSE would need to change this line for their e2e remote integration
-      # tests to test SSE instead of streamable HTTP.
-      REMOTE_SERVER_TRANSPORT_MODULE: streamable_http_server
-      # $APP_NAME is set below because we need to shorten the repo owner's name, as a precaution
+#   # These e2d deployment tests are super useful, but require you to add a HEROKU_API_KEY to your repo's actions secrets.
+#   # --> Uncomment after adding HEROKU_API_KEY to your forked repo's github action secrets.
+#   remote:
+#     runs-on: ubuntu-latest
+#     env:
+#       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+#       API_KEY: ci-test-key
+#       # also note that github CI doesn't have access to your app's config vars, so here we're setting the remote
+#       # server type to streamable HTTP. Folks using SSE would need to change this line for their e2e remote integration
+#       # tests to test SSE instead of streamable HTTP.
+#       REMOTE_SERVER_TRANSPORT_MODULE: streamable_http_server
+#       # $APP_NAME is set below because we need to shorten the repo owner's name, as a precaution
 
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # <-- disables shallow clone, which heroku is upset by when running git push heroku later on
+#     steps:
+#       - uses: actions/checkout@v4
+#         with:
+#           fetch-depth: 0  # <-- disables shallow clone, which heroku is upset by when running git push heroku later on
 
-      # Setting a short $APP_NAME that will be unique even if folks choose to fork this repo --> avoids clashes.
-      # Needs to be shortened if the github repo owner has a long name (max 30 char app name heroku limit).
-      - name: Generate short APP_NAME
-        id: appname
-        run: |
-          OWNER_SHORT=${GITHUB_REPOSITORY_OWNER:0:5}
-          REPO_NAME=$(basename "$GITHUB_REPOSITORY")
-          PR_NUMBER=$(jq .number "$GITHUB_EVENT_PATH")
-          APP_NAME="${OWNER_SHORT}-${REPO_NAME}-${PR_NUMBER}"
-          echo "APP_NAME=$APP_NAME"
-          echo "APP_NAME=$APP_NAME" >> $GITHUB_ENV
+#       # Setting a short $APP_NAME that will be unique even if folks choose to fork this repo --> avoids clashes.
+#       # Needs to be shortened if the github repo owner has a long name (max 30 char app name heroku limit).
+#       - name: Generate short APP_NAME
+#         id: appname
+#         run: |
+#           OWNER_SHORT=${GITHUB_REPOSITORY_OWNER:0:5}
+#           REPO_NAME=$(basename "$GITHUB_REPOSITORY")
+#           PR_NUMBER=$(jq .number "$GITHUB_EVENT_PATH")
+#           APP_NAME="${OWNER_SHORT}-${REPO_NAME}-${PR_NUMBER}"
+#           echo "APP_NAME=$APP_NAME"
+#           echo "APP_NAME=$APP_NAME" >> $GITHUB_ENV
 
-      - name: Read Python version from .python-version
-        id: python-version
-        run: |
-          PY_VERSION=$(cat .python-version)
-          echo "version=$PY_VERSION" >> $GITHUB_OUTPUT
+#       - name: Read Python version from .python-version
+#         id: python-version
+#         run: |
+#           PY_VERSION=$(cat .python-version)
+#           echo "version=$PY_VERSION" >> $GITHUB_OUTPUT
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ steps.python-version.outputs.version }}
+#       - uses: actions/setup-python@v5
+#         with:
+#           python-version: ${{ steps.python-version.outputs.version }}
 
-      - name: Read Node.js version from package.json
-        id: node-version
-        run: |
-          NODE_VERSION=$(jq -r '.engines.node' package.json)
-          echo "version=$NODE_VERSION" >> $GITHUB_OUTPUT
+#       - name: Read Node.js version from package.json
+#         id: node-version
+#         run: |
+#           NODE_VERSION=$(jq -r '.engines.node' package.json)
+#           echo "version=$NODE_VERSION" >> $GITHUB_OUTPUT
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
+#       - uses: actions/setup-node@v4
+#         with:
+#           node-version: ${{ steps.node-version.outputs.version }}
 
-      - name: Install Heroku CLI
-        run: |
-          curl https://cli-assets.heroku.com/install.sh | sh
+#       - name: Install Heroku CLI
+#         run: |
+#           curl https://cli-assets.heroku.com/install.sh | sh
 
-      - name: Log in to Heroku
-        run: |
-          echo "$HEROKU_API_KEY" | heroku auth:token
+#       - name: Log in to Heroku
+#         run: |
+#           echo "$HEROKU_API_KEY" | heroku auth:token
 
-      - name: Pre-cleanup (destroy app if it exists)
-        continue-on-error: true
-        run: |
-          heroku apps:destroy --app $APP_NAME --confirm $APP_NAME
+#       - name: Pre-cleanup (destroy app if it exists)
+#         continue-on-error: true
+#         run: |
+#           heroku apps:destroy --app $APP_NAME --confirm $APP_NAME
 
-      # github CI can't use our app.json, so the config etc bits must be set manually.
-      # note WEB_CONCURRENCY is important! You get non-deterministic errors w/out it.
-      - name: Create temp Heroku app for this PR
-        run: |
-          heroku create $APP_NAME
-          heroku buildpacks:add --index 1 heroku/nodejs -a $APP_NAME
-          heroku buildpacks:add --index 2 heroku/python -a $APP_NAME
-          heroku config:set API_KEY=$API_KEY --app $APP_NAME
-          heroku config:set STDIO_MODE_ONLY=false
-          heroku config:set REMOTE_SERVER_TRANSPORT_MODULE=$REMOTE_SERVER_TRANSPORT_MODULE --app $APP_NAME
-          heroku config:set WEB_CONCURRENCY=1 --app $APP_NAME
+#       # github CI can't use our app.json, so the config etc bits must be set manually.
+#       # note WEB_CONCURRENCY is important! You get non-deterministic errors w/out it.
+#       - name: Create temp Heroku app for this PR
+#         run: |
+#           heroku create $APP_NAME
+#           heroku buildpacks:add --index 1 heroku/nodejs -a $APP_NAME
+#           heroku buildpacks:add --index 2 heroku/python -a $APP_NAME
+#           heroku config:set API_KEY=$API_KEY --app $APP_NAME
+#           heroku config:set STDIO_MODE_ONLY=false
+#           heroku config:set REMOTE_SERVER_TRANSPORT_MODULE=$REMOTE_SERVER_TRANSPORT_MODULE --app $APP_NAME
+#           heroku config:set WEB_CONCURRENCY=1 --app $APP_NAME
 
-      - name: Deploy this branch to Heroku
-        run: |
-          git push https://heroku:$HEROKU_API_KEY@git.heroku.com/$APP_NAME.git HEAD:refs/heads/main --force
+#       - name: Deploy this branch to Heroku
+#         run: |
+#           git push https://heroku:$HEROKU_API_KEY@git.heroku.com/$APP_NAME.git HEAD:refs/heads/main --force
 
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+#       - uses: actions/cache@v4
+#         with:
+#           path: ~/.cache/pip
+#           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
 
-      - name: Install test dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+#       - name: Install test dependencies
+#         run: |
+#           python -m pip install --upgrade pip
+#           pip install -r requirements.txt
 
-      - name: Get Heroku env vars
-        id: heroku_env
-        run: |
-          url=$(heroku info -s -a $APP_NAME | grep web_url | cut -d= -f2 | tr -d '\n')
-          echo "url=$url" >> "$GITHUB_OUTPUT"
+#       - name: Get Heroku env vars
+#         id: heroku_env
+#         run: |
+#           url=$(heroku info -s -a $APP_NAME | grep web_url | cut -d= -f2 | tr -d '\n')
+#           echo "url=$url" >> "$GITHUB_OUTPUT"
 
-      - name: Run pytest against deployed app
-        env:
-            MCP_SERVER_URL: ${{ steps.heroku_env.outputs.url }}
-        run: |
-          echo "APP_NAME = $APP_NAME"
-          echo "MCP_SERVER_URL = $MCP_SERVER_URL"
-          echo "REMOTE_SERVER_TRANSPORT_MODULE = $REMOTE_SERVER_TRANSPORT_MODULE"
-          echo "API_KEY is ${API_KEY:+set}"  # won't print the key, just confirms it's non-empty
-          pytest -q
+#       - name: Run pytest against deployed app
+#         env:
+#             MCP_SERVER_URL: ${{ steps.heroku_env.outputs.url }}
+#         run: |
+#           echo "APP_NAME = $APP_NAME"
+#           echo "MCP_SERVER_URL = $MCP_SERVER_URL"
+#           echo "REMOTE_SERVER_TRANSPORT_MODULE = $REMOTE_SERVER_TRANSPORT_MODULE"
+#           echo "API_KEY is ${API_KEY:+set}"  # won't print the key, just confirms it's non-empty
+#           pytest -q
 
-      - name: Destroy Heroku app after test
-        if: always()
-        run: |
-          heroku apps:destroy --app $APP_NAME --confirm $APP_NAME
+#       - name: Destroy Heroku app after test
+#         if: always()
+#         run: |
+#           heroku apps:destroy --app $APP_NAME --confirm $APP_NAME

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
   # 2 - Deploy this PR to a temp Heroku app and run tests against deployed app (in addition to 'local')
   ###########################################################################
   remote:
+    if: false  # These e2d depployment tests are super useful, but require you to add a HEROKU_API_KEY to your repo's actions secrets.
     runs-on: ubuntu-latest
     env:
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}


### PR DESCRIPTION
Mauricio brought up a very valid security risk associated w/ running our e2e integration tests in github CI. --> Removed our github secrets, and therefore need to not run our deployment e2e testing in CI.

https://salesforce-internal.slack.com/archives/C06E0A422BA/p1750286355664199